### PR TITLE
Fixed :flavor->flavor bug in client.rb

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -20,7 +20,7 @@
 # Installs InfluxDB client libraries
 
 [:cli, :ruby].each do |flavor|
-  next unless node[:influxdb][:client][:flavor][:enable]
+  next unless node[:influxdb][:client][flavor][:enable]
 
   include_recipe "influxdb::#{flavor}_client"
 end

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -20,7 +20,7 @@
 # Installs InfluxDB client libraries
 
 [:cli, :ruby].each do |flavor|
-  next unless node[:influxdb][:client][flavor][:enable]
+  next unless (node[:influxdb][:client][flavor][:enable] rescue nil)
 
   include_recipe "influxdb::#{flavor}_client"
 end


### PR DESCRIPTION
Looks like a bug where 

` node[:influxdb][:client][:flavor][:enable]` 

should have been

` node[:influxdb][:client][flavor][:enable]`

(flavor should be a variable not a symbol)

Also fixed an issue that if a flavor was not set in the attribute it would exception.