### PR TITLE
Removed Checksum from influxdb pkg download

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,16 +22,6 @@
 # Versions are mapped to checksums
 # By default, always installs 'latest'
 default[:influxdb][:version] = 'latest'
-default[:influxdb][:versions] = {
-  amd64: {
-    '0.8.5' => '58ae034557e6a2886530577ab368ed2153b4e0a41bcfa57d8b15a9d5006f14d0',
-    :latest => '58ae034557e6a2886530577ab368ed2153b4e0a41bcfa57d8b15a9d5006f14d0'
-  },
-  i686: {
-    '0.8.5' => 'b551d6d152c9af6e66a1eba3c07578a20678d0d3f3efa8852f19e2befd96a7fd',
-    :latest => 'b551d6d152c9af6e66a1eba3c07578a20678d0d3f3efa8852f19e2befd96a7fd'
-  }
-}
 
 # Default influxdb recipe action. Consider [:create, :start]
 default[:influxdb][:action] = [:create]

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,7 +25,6 @@ node.default[:influxdb][:source] = "http://s3.amazonaws.com/influxdb/influxdb_#{
 
 influxdb 'main' do
   source node[:influxdb][:source]
-  checksum node[:influxdb][:versions][arch][ver]
   config node[:influxdb][:config]
   action node[:influxdb][:action]
 end


### PR DESCRIPTION
This PR fix the issue #39.

Tests:
```shell
(tws)➜  chef-influxdb git:(feature/remove/checksum) kitchen converge default-ubuntu-1404
-----> Starting Kitchen (v1.2.1)
-----> Creating <default-ubuntu-1404>...
       Bringing machine 'default' up with 'virtualbox' provider...
       [default] Box 'opscode_ubuntu-14.04' was not found. Fetching box from specified URL for
       the provider 'virtualbox'. Note that if the URL does not have
       a box for this provider, you should interrupt Vagrant now and add
       the box yourself. Otherwise Vagrant will attempt to download the
       full box prior to discovering this error.
       Downloading or copying the box...
       Extracting box...k/s, Estimated time remaining: 0:00:01)
       Successfully added box 'opscode_ubuntu-14.04' with provider 'virtualbox'!
       [default] Importing base box 'opscode_ubuntu-14.04'...
       [default] Matching MAC address for NAT networking...
       [default] Setting the name of the VM...
       [default] Clearing any previously set forwarded ports...
       [default] Fixed port collision for 22 => 2222. Now on port 2200.
       [default] Creating shared folders metadata...
       [default] Clearing any previously set network interfaces...
       [default] Preparing network interfaces based on configuration...
[default] Forwarding ports...       [default] -- 22 => 2200 (adapter 1)
       [default] Running 'pre-boot' VM customizations...
       [default] Booting VM...
       [default] Waiting for machine to boot. This may take a few minutes...
       [default] Machine booted and ready!
       [default] Setting hostname...
       [default] Mounting shared folders...
       Vagrant instance <default-ubuntu-1404> created.
       Finished creating <default-ubuntu-1404> (21m35.34s).
-----> Converging <default-ubuntu-1404>...
       Preparing files for transfer
       Resolving cookbook dependencies with Berkshelf 3.1.4...
       Removing non-cookbook files before transfer
-----> Installing Chef Omnibus (11.8.2)
downloading https://www.getchef.com/chef/install.sh
         to file /tmp/install.sh
       trying wget...
Downloading Chef 11.8.2 for ubuntu...
downloading https://www.chef.io/chef/metadata?v=11.8.2&prerelease=false&nightlies=false&p=ubuntu&pv=14.04&m=x86_64
  to file /tmp/install.sh.1311/metadata.txt
trying wget...
url	https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/13.04/x86_64/chef_11.8.2-1.ubuntu.13.04_amd64.deb
md5	7330b13d6aa17dad8b9e9ae6a018aef7
sha256	dd9bdb08db56cd44c556b3ff59a63d2500954215ec9bec6ed60c939d1991b354
yolo	true
downloaded metadata file looks valid...
downloading https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/13.04/x86_64/chef_11.8.2-1.ubuntu.13.04_amd64.deb
  to file /tmp/install.sh.1311/chef_11.8.2-1.ubuntu.13.04_amd64.deb
trying wget...
Comparing checksum with sha256sum...

WARNING: Chef-Client has not been regression tested on this O/S Distribution
WARNING: Do not use this configuration for Production Applications.  Use at your own risk.

Installing Chef 11.8.2
installing with dpkg...
Selecting previously unselected package chef.
(Reading database ... 32400 files and directories currently installed.)
Preparing to unpack .../chef_11.8.2-1.ubuntu.13.04_amd64.deb ...
Unpacking chef (11.8.2-1.ubuntu.13.04) ...
Setting up chef (11.8.2-1.ubuntu.13.04) ...
Thank you for installing Chef!
       Transfering files to <default-ubuntu-1404>
[2015-01-27T17:37:49+00:00] INFO: Forking chef instance to converge...
Starting Chef Client, version 11.8.2
[2015-01-27T17:37:49+00:00] INFO: *** Chef 11.8.2 ***
[2015-01-27T17:37:49+00:00] INFO: Chef-client pid: 1409
[2015-01-27T17:37:50+00:00] INFO: Setting the run_list to ["recipe[apt::default]", "recipe[influxdb::default]"] from JSON
[2015-01-27T17:37:50+00:00] INFO: Run List is [recipe[apt::default], recipe[influxdb::default]]
[2015-01-27T17:37:50+00:00] INFO: Run List expands to [apt::default, influxdb::default]
[2015-01-27T17:37:50+00:00] INFO: Starting Chef Run for default-ubuntu-1404
[2015-01-27T17:37:50+00:00] INFO: Running start handlers
[2015-01-27T17:37:50+00:00] INFO: Start handlers complete.
Compiling Cookbooks...
Converging 9 resources
Recipe: apt::default
  * execute[apt-get-update] action run[2015-01-27T17:37:50+00:00] INFO: Processing execute[apt-get-update] action run (apt::default line 45)
Ign http://us.archive.ubuntu.com trusty InRelease
Ign http://security.ubuntu.com trusty-security InRelease
Ign http://us.archive.ubuntu.com trusty-updates InRelease
Get:1 http://security.ubuntu.com trusty-security Release.gpg [933 B]
Ign http://us.archive.ubuntu.com trusty-backports InRelease
Get:2 http://security.ubuntu.com trusty-security Release [62.0 kB]
Hit http://us.archive.ubuntu.com trusty Release.gpg
Get:3 http://us.archive.ubuntu.com trusty-updates Release.gpg [933 B]
Get:4 http://us.archive.ubuntu.com trusty-backports Release.gpg [933 B]
Get:5 http://security.ubuntu.com trusty-security/main Sources [64.8 kB]
Hit http://us.archive.ubuntu.com trusty Release
Get:6 http://us.archive.ubuntu.com trusty-updates Release [62.0 kB]
Get:7 http://us.archive.ubuntu.com trusty-backports Release [62.0 kB]
Get:8 http://security.ubuntu.com trusty-security/restricted Sources [2061 B]
Get:9 http://security.ubuntu.com trusty-security/universe Sources [17.4 kB]
Hit http://us.archive.ubuntu.com trusty/main Sources
Get:10 http://security.ubuntu.com trusty-security/multiverse Sources [723 B]
Hit http://us.archive.ubuntu.com trusty/restricted Sources
Get:11 http://security.ubuntu.com trusty-security/main amd64 Packages [200 kB]
Hit http://us.archive.ubuntu.com trusty/universe Sources
Hit http://us.archive.ubuntu.com trusty/multiverse Sources
Hit http://us.archive.ubuntu.com trusty/main amd64 Packages
Hit http://us.archive.ubuntu.com trusty/restricted amd64 Packages
Get:12 http://security.ubuntu.com trusty-security/restricted amd64 Packages [8875 B]
Hit http://us.archive.ubuntu.com trusty/universe amd64 Packages
Get:13 http://security.ubuntu.com trusty-security/universe amd64 Packages [85.3 kB]
Hit http://us.archive.ubuntu.com trusty/multiverse amd64 Packages
Hit http://us.archive.ubuntu.com trusty/main i386 Packages
Get:14 http://security.ubuntu.com trusty-security/multiverse amd64 Packages [1161 B]
Hit http://us.archive.ubuntu.com trusty/restricted i386 Packages
Get:15 http://security.ubuntu.com trusty-security/main i386 Packages [190 kB]
Hit http://us.archive.ubuntu.com trusty/universe i386 Packages
Hit http://us.archive.ubuntu.com trusty/multiverse i386 Packages
Hit http://us.archive.ubuntu.com trusty/main Translation-en
Hit http://us.archive.ubuntu.com trusty/multiverse Translation-en
Get:16 http://security.ubuntu.com trusty-security/restricted i386 Packages [8846 B]
Hit http://us.archive.ubuntu.com trusty/restricted Translation-en
Get:17 http://security.ubuntu.com trusty-security/universe i386 Packages [85.3 kB]
Hit http://us.archive.ubuntu.com trusty/universe Translation-en
Get:18 http://us.archive.ubuntu.com trusty-updates/main Sources [158 kB]
Get:19 http://security.ubuntu.com trusty-security/multiverse i386 Packages [1412 B]
Get:20 http://security.ubuntu.com trusty-security/main Translation-en [101 kB]
Hit http://security.ubuntu.com trusty-security/multiverse Translation-en
Get:21 http://security.ubuntu.com trusty-security/restricted Translation-en [2266 B]
Get:22 http://us.archive.ubuntu.com trusty-updates/restricted Sources [2061 B]
Get:23 http://us.archive.ubuntu.com trusty-updates/universe Sources [97.6 kB]
Get:24 http://security.ubuntu.com trusty-security/universe Translation-en [46.8 kB]
Get:25 http://us.archive.ubuntu.com trusty-updates/multiverse Sources [3553 B]
Get:26 http://us.archive.ubuntu.com trusty-updates/main amd64 Packages [406 kB]
Get:27 http://us.archive.ubuntu.com trusty-updates/restricted amd64 Packages [8875 B]
Get:28 http://us.archive.ubuntu.com trusty-updates/universe amd64 Packages [241 kB]
Get:29 http://us.archive.ubuntu.com trusty-updates/multiverse amd64 Packages [9382 B]
Get:30 http://us.archive.ubuntu.com trusty-updates/main i386 Packages [397 kB]
Get:31 http://us.archive.ubuntu.com trusty-updates/restricted i386 Packages [8846 B]
Get:32 http://us.archive.ubuntu.com trusty-updates/universe i386 Packages [241 kB]
Get:33 http://us.archive.ubuntu.com trusty-updates/multiverse i386 Packages [9558 B]
Get:34 http://us.archive.ubuntu.com trusty-updates/main Translation-en [193 kB]
Hit http://us.archive.ubuntu.com trusty-updates/multiverse Translation-en
Get:35 http://us.archive.ubuntu.com trusty-updates/restricted Translation-en [2266 B]
Get:36 http://us.archive.ubuntu.com trusty-updates/universe Translation-en [124 kB]
Get:37 http://us.archive.ubuntu.com trusty-backports/main Sources [4451 B]
Get:38 http://us.archive.ubuntu.com trusty-backports/restricted Sources [28 B]
Get:39 http://us.archive.ubuntu.com trusty-backports/universe Sources [19.6 kB]
Get:40 http://us.archive.ubuntu.com trusty-backports/multiverse Sources [1898 B]
Get:41 http://us.archive.ubuntu.com trusty-backports/main amd64 Packages [5165 B]
Get:42 http://us.archive.ubuntu.com trusty-backports/restricted amd64 Packages [28 B]
Get:43 http://us.archive.ubuntu.com trusty-backports/universe amd64 Packages [23.9 kB]
Get:44 http://us.archive.ubuntu.com trusty-backports/multiverse amd64 Packages [1245 B]
Get:45 http://us.archive.ubuntu.com trusty-backports/main i386 Packages [5176 B]
Get:46 http://us.archive.ubuntu.com trusty-backports/restricted i386 Packages [28 B]
Get:47 http://us.archive.ubuntu.com trusty-backports/universe i386 Packages [24.0 kB]
Get:48 http://us.archive.ubuntu.com trusty-backports/multiverse i386 Packages [1249 B]
Get:49 http://us.archive.ubuntu.com trusty-backports/main Translation-en [3043 B]
Hit http://us.archive.ubuntu.com trusty-backports/multiverse Translation-en
Hit http://us.archive.ubuntu.com trusty-backports/restricted Translation-en
Get:50 http://us.archive.ubuntu.com trusty-backports/universe Translation-en [21.8 kB]
Fetched 3018 kB in 26s (116 kB/s)
Reading package lists...
[2015-01-27T17:38:21+00:00] INFO: execute[apt-get-update] ran successfully

    - execute apt-get update

  * execute[apt-get update] action nothing[2015-01-27T17:38:21+00:00] INFO: Processing execute[apt-get update] action nothing (apt::default line 53)
 (skipped due to action :nothing)
  * execute[apt-get autoremove] action nothing[2015-01-27T17:38:21+00:00] INFO: Processing execute[apt-get autoremove] action nothing (apt::default line 61)
 (skipped due to action :nothing)
  * execute[apt-get autoclean] action nothing[2015-01-27T17:38:21+00:00] INFO: Processing execute[apt-get autoclean] action nothing (apt::default line 68)
 (skipped due to action :nothing)
  * package[update-notifier-common] action install[2015-01-27T17:38:21+00:00] INFO: Processing package[update-notifier-common] action install (apt::default line 75)

    - install version 0.154.1ubuntu1 of package update-notifier-common

[2015-01-27T17:38:32+00:00] INFO: package[update-notifier-common] sending run action to execute[apt-get-update] (immediate)
  * execute[apt-get-update] action run[2015-01-27T17:38:32+00:00] INFO: Processing execute[apt-get-update] action run (apt::default line 45)
Ign http://us.archive.ubuntu.com trusty InRelease
Ign http://security.ubuntu.com trusty-security InRelease
Ign http://us.archive.ubuntu.com trusty-updates InRelease
Hit http://security.ubuntu.com trusty-security Release.gpg
Ign http://us.archive.ubuntu.com trusty-backports InRelease
Hit http://security.ubuntu.com trusty-security Release
Hit http://us.archive.ubuntu.com trusty Release.gpg
Hit http://security.ubuntu.com trusty-security/main Sources
Hit http://us.archive.ubuntu.com trusty-updates Release.gpg
Hit http://security.ubuntu.com trusty-security/restricted Sources
Hit http://us.archive.ubuntu.com trusty-backports Release.gpg
Hit http://security.ubuntu.com trusty-security/universe Sources
Hit http://us.archive.ubuntu.com trusty Release
Hit http://security.ubuntu.com trusty-security/multiverse Sources
Hit http://us.archive.ubuntu.com trusty-updates Release
Hit http://security.ubuntu.com trusty-security/main amd64 Packages
Hit http://us.archive.ubuntu.com trusty-backports Release
Hit http://security.ubuntu.com trusty-security/restricted amd64 Packages
Hit http://us.archive.ubuntu.com trusty/main Sources
Hit http://security.ubuntu.com trusty-security/universe amd64 Packages
Hit http://us.archive.ubuntu.com trusty/restricted Sources
Hit http://security.ubuntu.com trusty-security/multiverse amd64 Packages
Hit http://us.archive.ubuntu.com trusty/universe Sources
Hit http://security.ubuntu.com trusty-security/main i386 Packages
Hit http://us.archive.ubuntu.com trusty/multiverse Sources
Hit http://security.ubuntu.com trusty-security/restricted i386 Packages
Hit http://us.archive.ubuntu.com trusty/main amd64 Packages
Hit http://security.ubuntu.com trusty-security/universe i386 Packages
Hit http://us.archive.ubuntu.com trusty/restricted amd64 Packages
Hit http://security.ubuntu.com trusty-security/multiverse i386 Packages
Hit http://us.archive.ubuntu.com trusty/universe amd64 Packages
Hit http://security.ubuntu.com trusty-security/main Translation-en
Hit http://us.archive.ubuntu.com trusty/multiverse amd64 Packages
Hit http://security.ubuntu.com trusty-security/multiverse Translation-en
Hit http://us.archive.ubuntu.com trusty/main i386 Packages
Hit http://security.ubuntu.com trusty-security/restricted Translation-en
Hit http://us.archive.ubuntu.com trusty/restricted i386 Packages
Hit http://security.ubuntu.com trusty-security/universe Translation-en
Hit http://us.archive.ubuntu.com trusty/universe i386 Packages
Hit http://us.archive.ubuntu.com trusty/multiverse i386 Packages
Hit http://us.archive.ubuntu.com trusty/main Translation-en
Hit http://us.archive.ubuntu.com trusty/multiverse Translation-en
Hit http://us.archive.ubuntu.com trusty/restricted Translation-en
Hit http://us.archive.ubuntu.com trusty/universe Translation-en
Hit http://us.archive.ubuntu.com trusty-updates/main Sources
Hit http://us.archive.ubuntu.com trusty-updates/restricted Sources
Hit http://us.archive.ubuntu.com trusty-updates/universe Sources
Hit http://us.archive.ubuntu.com trusty-updates/multiverse Sources
Hit http://us.archive.ubuntu.com trusty-updates/main amd64 Packages
Hit http://us.archive.ubuntu.com trusty-updates/restricted amd64 Packages
Hit http://us.archive.ubuntu.com trusty-updates/universe amd64 Packages
Hit http://us.archive.ubuntu.com trusty-updates/multiverse amd64 Packages
Hit http://us.archive.ubuntu.com trusty-updates/main i386 Packages
Hit http://us.archive.ubuntu.com trusty-updates/restricted i386 Packages
Hit http://us.archive.ubuntu.com trusty-updates/universe i386 Packages
Hit http://us.archive.ubuntu.com trusty-updates/multiverse i386 Packages
Hit http://us.archive.ubuntu.com trusty-updates/main Translation-en
Hit http://us.archive.ubuntu.com trusty-updates/multiverse Translation-en
Hit http://us.archive.ubuntu.com trusty-updates/restricted Translation-en
Hit http://us.archive.ubuntu.com trusty-updates/universe Translation-en
Hit http://us.archive.ubuntu.com trusty-backports/main Sources
Hit http://us.archive.ubuntu.com trusty-backports/restricted Sources
Hit http://us.archive.ubuntu.com trusty-backports/universe Sources
Hit http://us.archive.ubuntu.com trusty-backports/multiverse Sources
Hit http://us.archive.ubuntu.com trusty-backports/main amd64 Packages
Hit http://us.archive.ubuntu.com trusty-backports/restricted amd64 Packages
Hit http://us.archive.ubuntu.com trusty-backports/universe amd64 Packages
Hit http://us.archive.ubuntu.com trusty-backports/multiverse amd64 Packages
Hit http://us.archive.ubuntu.com trusty-backports/main i386 Packages
Hit http://us.archive.ubuntu.com trusty-backports/restricted i386 Packages
Hit http://us.archive.ubuntu.com trusty-backports/universe i386 Packages
Hit http://us.archive.ubuntu.com trusty-backports/multiverse i386 Packages
Hit http://us.archive.ubuntu.com trusty-backports/main Translation-en
Hit http://us.archive.ubuntu.com trusty-backports/multiverse Translation-en
Hit http://us.archive.ubuntu.com trusty-backports/restricted Translation-en
Hit http://us.archive.ubuntu.com trusty-backports/universe Translation-en
Reading package lists...
[2015-01-27T17:38:54+00:00] INFO: execute[apt-get-update] ran successfully

    - execute apt-get update

  * execute[apt-get-update-periodic] action run[2015-01-27T17:38:54+00:00] INFO: Processing execute[apt-get-update-periodic] action run (apt::default line 80)
 (skipped due to only_if)
  * directory[/var/cache/local] action create[2015-01-27T17:38:54+00:00] INFO: Processing directory[/var/cache/local] action create (apt::default line 91)
[2015-01-27T17:38:54+00:00] INFO: directory[/var/cache/local] created directory /var/cache/local

    - create new directory /var/cache/local[2015-01-27T17:38:54+00:00] INFO: directory[/var/cache/local] owner changed to 0
[2015-01-27T17:38:54+00:00] INFO: directory[/var/cache/local] group changed to 0
[2015-01-27T17:38:54+00:00] INFO: directory[/var/cache/local] mode changed to 755

    - change mode from '' to '0755'
    - change owner from '' to 'root'
    - change group from '' to 'root'

  * directory[/var/cache/local/preseeding] action create[2015-01-27T17:38:54+00:00] INFO: Processing directory[/var/cache/local/preseeding] action create (apt::default line 91)
[2015-01-27T17:38:54+00:00] INFO: directory[/var/cache/local/preseeding] created directory /var/cache/local/preseeding

    - create new directory /var/cache/local/preseeding[2015-01-27T17:38:54+00:00] INFO: directory[/var/cache/local/preseeding] owner changed to 0
[2015-01-27T17:38:54+00:00] INFO: directory[/var/cache/local/preseeding] group changed to 0
[2015-01-27T17:38:54+00:00] INFO: directory[/var/cache/local/preseeding] mode changed to 755

    - change mode from '' to '0755'
    - change owner from '' to 'root'
    - change group from '' to 'root'

Recipe: influxdb::default
  * influxdb[main] action create[2015-01-27T17:38:54+00:00] INFO: Processing influxdb[main] action create (influxdb::default line 26)
Recipe: <Dynamically Defined Resource>
  * remote_file[/tmp/kitchen/cache/influxdb.deb] action create[2015-01-27T17:38:54+00:00] INFO: Processing remote_file[/tmp/kitchen/cache/influxdb.deb] action create (dynamically defined)
[2015-01-27T17:38:54+00:00] INFO: remote_file[/tmp/kitchen/cache/influxdb.deb] created file /tmp/kitchen/cache/influxdb.deb

    - create new file /tmp/kitchen/cache/influxdb.deb[2015-01-27T17:39:50+00:00] INFO: remote_file[/tmp/kitchen/cache/influxdb.deb] updated file contents /tmp/kitchen/cache/influxdb.deb

    - update content in file /tmp/kitchen/cache/influxdb.deb from none to 04f0b7
        (file sizes exceed 10000000 bytes, diff output suppressed)

  * package[/tmp/kitchen/cache/influxdb.deb] action install[2015-01-27T17:39:50+00:00] INFO: Processing package[/tmp/kitchen/cache/influxdb.deb] action install (dynamically defined)

    - install version 0.8.8 of package /tmp/kitchen/cache/influxdb.deb

  * service[influxdb] action enable[2015-01-27T17:39:52+00:00] INFO: Processing service[influxdb] action enable (dynamically defined)
[2015-01-27T17:39:52+00:00] INFO: service[influxdb] enabled

    - enable service service[influxdb]

  * chef_gem[toml] action install[2015-01-27T17:39:52+00:00] INFO: Processing chef_gem[toml] action install (dynamically defined)

    - install version 0.1.2 of package toml

  * file[/opt/influxdb/shared/config.toml] action create[2015-01-27T17:40:23+00:00] INFO: Processing file[/opt/influxdb/shared/config.toml] action create (dynamically defined)
[2015-01-27T17:40:23+00:00] INFO: file[/opt/influxdb/shared/config.toml] backed up to /tmp/kitchen/backup/opt/influxdb/shared/config.toml.chef-20150127174023.878825
[2015-01-27T17:40:23+00:00] INFO: file[/opt/influxdb/shared/config.toml] updated file contents /opt/influxdb/shared/config.toml

    - update content in file /opt/influxdb/shared/config.toml from 6d22d7 to a0db9b
        --- /opt/influxdb/shared/config.toml	2015-01-27 17:39:51.854814764 +0000
        +++ /tmp/.config.toml20150127-1409-al1ycu	2015-01-27 17:40:23.866814593 +0000
        @@ -1,200 +1,65 @@
        -# Welcome to the InfluxDB configuration file.

        -
        -# If hostname (on the OS) doesn't return a name that can be resolved by the other
        -# systems in the cluster, you'll have to set the hostname to an IP or something
        -# that can be resolved here.

        -# hostname = ""
        -
         bind-address = "0.0.0.0"
        -
        -# Once every 24 hours InfluxDB will report anonymous data to m.influxdb.com

        -# The data includes raft name (random 8 bytes), os, arch and version
        -# We don't track ip addresses of servers reporting. This is only used
        -# to track the number of instances running and the versions which

        -# is very helpful for us.
        -# Change this option to true to disable reporting.
         reporting-disabled = false

        -[logging]

        -# logging level can be one of "fine", "debug", "info", "warn" or "error"
        -level  = "info"
        -file   = "/opt/influxdb/shared/log.txt"         # stdout to log to standard out, or syslog facility
        -
        -# Configure the admin server
         [admin]
        -port   = 8083              # binding is disabled if the port isn't set
        +port = 8083


        -# Configure the http api
         [api]
        -port     = 8086    # binding is disabled if the port isn't set
        -# ssl-port = 8087    # Ssl support is enabled if you set a port and cert
        -# ssl-cert = /path/to/cert.pem
        -
        -# connections will timeout after this amount of time. Ensures that clients that misbehave

        -# and keep alive connections they don't use won't end up connection a million times.
        -# However, if a request is taking longer than this to complete, could be a problem.
        +port = 8086
         read-timeout = "5s"

        -[input_plugins]
        +[cluster]
        +concurrent-shard-query-limit = 10
        +max-response-buffer-size = 100

        +protobuf_heartbeat = "200ms"
        +protobuf_max_backoff = "10s"
        +protobuf_min_backoff = "1s"
        +protobuf_port = 8099
        +protobuf_timeout = "2s"

        +write-buffer-size = 1000

        -  # Configure the graphite api
        -  [input_plugins.graphite]
        -  enabled = false
        -  # address = "0.0.0.0" # If not set, is actually set to bind-address.
        -  # port = 2003

        -  # database = ""  # store graphite data in this database
        -  # udp_enabled = true # enable udp interface on the same port as the tcp interface
        +[input_plugins.graphite]
        +enabled = false

        -  # Configure the collectd api
        -  [input_plugins.collectd]
        -  enabled = false
        -  # address = "0.0.0.0" # If not set, is actually set to bind-address.
        -  # port = 25826
        -  # database = ""
        -  # types.db can be found in a collectd installation or on github:
        -  # https://github.com/collectd/collectd/blob/master/src/types.db
        -  # typesdb = "/usr/share/collectd/types.db" # The path to the collectd types.db file

        +[input_plugins.udp]
        +enabled = false

        -  # Configure the udp api
        -  [input_plugins.udp]
        -  enabled = false

        -  # port = 4444
        -  # database = ""
        +[logging]
        +file = "/opt/influxdb/shared/log.txt"
        +level = "info"


        -  # Configure multiple udp apis each can write to separate db.  Just
        -  # repeat the following section to enable multiple udp apis on
        -  # different ports.
        -  [[input_plugins.udp_servers]] # array of tables
        -  enabled = false
        -  # port = 5551

        -  # database = "db1"
        -
        -# Raft configuration
         [raft]
        -# The raft port should be open between all servers in a cluster.
        -# However, this port shouldn't be accessible from the internet.
        -
        +dir = "/opt/influxdb/shared/data/raft"

         port = 8090

        -# Where the raft logs are stored. The user running InfluxDB will need read/write access.
        -dir  = "/opt/influxdb/shared/data/raft"
        -
        -debug = false
        -

        -# election-timeout = "1s"
        -
         [storage]
        -
        +default-engine = "rocksdb"
         dir = "/opt/influxdb/shared/data/db"
        -# How many requests to potentially buffer in memory. If the buffer gets filled then writes
        -# will still be logged and once the local storage has caught up (or compacted) the writes
        -# will be replayed from the WAL
        -write-buffer-size = 10000

        -
        -# the engine to use for new shards, old shards will continue to use the same engine
        -default-engine = "leveldb"
        -
        -# The default setting on this is 0, which means unlimited. Set this to something if you want to
        -# limit the max number of open files. max-open-files is per shard so this * that will be max.
         max-open-shards = 0
        -

        -# The default setting is 100. This option tells how many points will be fetched from LevelDb before
        -# they get flushed into backend.
         point-batch-size = 100
        -
        -# The number of points to batch in memory before writing them to leveldb. Lowering this number will
        -# reduce the memory usage, but will result in slower writes.
        +retention-sweep-period = "10m"
         write-batch-size = 5000000
        +write-buffer-size = 10000



        -# The server will check this often for shards that have expired that should be cleared.
        -retention-sweep-period = "10m"
        -
        -[storage.engines.leveldb]
        -

        -# Maximum mmap open files, this will affect the virtual memory used by
        -# the process
        -max-open-files = 1000
        -
        -# LRU cache size, LRU is used by leveldb to store contents of the
        -# uncompressed sstables. You can use `m` or `g` prefix for megabytes

        -# and gigabytes, respectively.
        +[storage.engines.hyperleveldb]
         lru-cache-size = "200m"
        -
        -[storage.engines.rocksdb]
        -
        -# Maximum mmap open files, this will affect the virtual memory used by
        -# the process
         max-open-files = 1000

        -# LRU cache size, LRU is used by rocksdb to store contents of the
        -# uncompressed sstables. You can use `m` or `g` prefix for megabytes
        -# and gigabytes, respectively.
        +[storage.engines.leveldb]
         lru-cache-size = "200m"
        -
        -[storage.engines.hyperleveldb]
        -
        -# Maximum mmap open files, this will affect the virtual memory used by
        -# the process
         max-open-files = 1000


        -# LRU cache size, LRU is used by rocksdb to store contents of the
        -# uncompressed sstables. You can use `m` or `g` prefix for megabytes
        -# and gigabytes, respectively.
        -lru-cache-size = "200m"
        -
         [storage.engines.lmdb]

        -
         map-size = "100g"

        -[cluster]
        -# A comma separated list of servers to seed
        -# this server. this is only relevant when the

        -# server is joining a new cluster. Otherwise
        -# the server will use the list of known servers
        -# prior to shutting down. Any server can be pointed to
        -# as a seed. It will find the Raft leader automatically.
        +[storage.engines.rocksdb]
        +lru-cache-size = "200m"
        +max-open-files = 1000


        -# Here's an example. Note that the port on the host is the same as the raft port.
        -# seed-servers = ["hosta:8090","hostb:8090"]
        -
        -# Replication happens over a TCP connection with a Protobuf protocol.
        -# This port should be reachable between all servers in a cluster.
        -# However, this port shouldn't be accessible from the internet.
        -

        -protobuf_port = 8099
        -protobuf_timeout = "2s" # the write timeout on the protobuf conn any duration parseable by time.ParseDuration
        -protobuf_heartbeat = "200ms" # the heartbeat interval between the servers. must be parseable by time.ParseDuration
        -protobuf_min_backoff = "1s" # the minimum backoff after a failed heartbeat attempt
        -protobuf_max_backoff = "10s" # the maxmimum backoff after a failed heartbeat attempt
        -
        -# How many write requests to potentially buffer in memory per server. If the buffer gets filled then writes

        -# will still be logged and once the server has caught up (or come back online) the writes
        -# will be replayed from the WAL
        -write-buffer-size = 1000
        -
        -# the maximum number of responses to buffer from remote nodes, if the
        -# expected number of responses exceed this number then querying will
        -# happen sequentially and the buffer size will be limited to this
        -# number

        -max-response-buffer-size = 100
        -
        -# When queries get distributed out to shards, they go in parallel. This means that results can get buffered
        -# in memory since results will come in any order, but have to be processed in the correct time order.
        -# Setting this higher will give better performance, but you'll need more memory. Setting this to 1 will ensure
        -# that you don't need to buffer in memory, but you won't get the best performance.
        -concurrent-shard-query-limit = 10
        -
         [wal]
        -
        -dir   = "/opt/influxdb/shared/data/wal"

        -flush-after = 1000 # the number of writes after which wal will be flushed, 0 for flushing on every write
        -bookmark-after = 1000 # the number of writes after which a bookmark will be created
        -
        -# the number of writes after which an index entry is created pointing
        -# to the offset of the first request, default to 1k

        +bookmark-after = 1000
        +dir = "/opt/influxdb/shared/data/wal"
        +flush-after = 1000

         index-after = 1000
        -
        -# the number of requests per one log file, if new requests came in a
        -# new log file will be created
         requests-per-logfile = 10000
[2015-01-27T17:40:23+00:00] INFO: file[/opt/influxdb/shared/config.toml] owner changed to 0

    - change owner from 'influxdb' to 'root'

  * file[/opt/influxdb/shared/log.txt] action touch[2015-01-27T17:40:23+00:00] INFO: Processing file[/opt/influxdb/shared/log.txt] action touch (dynamically defined)
[2015-01-27T17:40:23+00:00] INFO: file[/opt/influxdb/shared/log.txt] updated atime and mtime to 2015-01-27 17:40:23 +0000

    - update utime on file /opt/influxdb/shared/log.txt

 (up to date)
[2015-01-27T17:40:23+00:00] INFO: Chef Run complete in 153.763381549 seconds
[2015-01-27T17:40:23+00:00] INFO: Running report handlers
[2015-01-27T17:40:23+00:00] INFO: Report handlers complete
Chef Client finished, 11 resources updated
       Finished converging <default-ubuntu-1404> (4m31.54s).
-----> Kitchen is finished. (26m7.58s)
```

Regards,