### PR TITLE
Make test/integration/zero_nine a copy instead of a symbolic link of test/integration/default

### DIFF
--- a/test/integration/zero_nine
+++ b/test/integration/zero_nine
@@ -1,1 +1,0 @@
-/Users/rberger/work/mist/cookbooks/chef-influxdb/test/integration/default

--- a/test/integration/zero_nine/serverspec/install_spec.rb
+++ b/test/integration/zero_nine/serverspec/install_spec.rb
@@ -1,0 +1,33 @@
+require 'serverspec'
+
+# Required by serverspec
+set :backend, :exec
+
+# include Serverspec::Helper::Exec
+# include Serverspec::Helper::DetectOS
+Serverspec.describe "influxdb" do
+  before(:all) do
+    status = `service influxdb status`
+    unless status =~ /OK/
+      puts "STARTING INFLUXDB: "
+      puts `service influxdb start`
+      sleep 1
+    end
+  end
+
+  describe user('influxdb') do
+    it { should exist }
+  end
+
+  describe service('influxdb') do
+    it { should be_running }
+  end
+
+  describe port(8083) do
+    it { should be_listening }
+  end
+
+  describe port(8086) do
+    it { should be_listening }
+  end
+end


### PR DESCRIPTION
Since there was a test kitchen suite `zero_nine` there needed to be a `test/integration/zero_nine`. Originally I made it a symbolic link to `test/integration/default` but it did seem that something (I believe in test kitchen) did not like test/integration/zero_nine being a symbolic link.  So this pull request just changes `test/integration/zero_nine` from a symbolic link to a copy of `test/integration/default`.

There may be a better way to do this by setting something in the .kitchen.yml to tell it to use `test/integration/default` or otherwise not have to make a copy (which is not very DRY) but I don't know for sure. 
