### PR TITLE
Fix the regex test for 0.9.x releases of InfluxDB.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.6.1
+* Fix the regex test for 0.9.x releases of InfluxDB.
+
 ## 2.6.0
 * Support for 0.9.x release of InfluxDB (contributed by @rberger)
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -20,7 +20,7 @@ maintainer       'Simple Finance Technology Corp'
 maintainer_email 'ops@simple.com'
 license          'Apache 2.0'
 description      'InfluxDB, a timeseries database'
-version          '2.6.0'
+version          '2.6.1'
 
 # For CLI client
 # https://github.com/balbeko/chef-npm

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,13 +25,13 @@ ver  = node[:influxdb][:version]
 arch = /x86_64/.match(node[:kernel][:machine]) ? 'amd64' : 'i686'
 node.default[:influxdb][:source] = "http://s3.amazonaws.com/influxdb/influxdb_#{ver}_#{arch}.deb"
 
-if (ver =~ /^0\.9\./)
-  influxdb_config =  node[:influxdb][:zero_nine][:config]
-  dirs = [node[:influxdb][:data_root_dir], influxdb_config[:data][:dir], influxdb_config[:broker][:dir]]
-else
+if (ver =~ /^0\.9\./).nil?
   node.set[:influxdb][:config_file_path] = "#{node[:influxdb][:install_root_dir]}/shared/config.toml"
   influxdb_config = node[:influxdb][:config]
   dirs = [node[:influxdb][:data_root_dir]]
+else
+  influxdb_config =  node[:influxdb][:zero_nine][:config]
+  dirs = [node[:influxdb][:data_root_dir], influxdb_config[:data][:dir], influxdb_config[:broker][:dir]]
 end
 
 pp_influxdb = PP.pp(node[:influxdb], '')


### PR DESCRIPTION
The =~ does not return true/false, it returns the position of the matching string, or nil if there is no match. If you actually set your version to 0.9.x, it would use the non-zero-nine config. And if you set your version to something other that 0.9, you would get the 0.9 config. Obviously this can't be correct.

I've done a simple fix to the test, though I disbelieve strongly in this approach to Chef configuration.