### PR TITLE
Support non-root:root credentials in the LWRPs

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -20,7 +20,7 @@ maintainer       'Simple Finance Technology Corp'
 maintainer_email 'ops@simple.com'
 license          'Apache 2.0'
 description      'InfluxDB, a timeseries database'
-version          '3.0.0'
+version          '3.1.0'
 
 # For CLI client
 # https://github.com/balbeko/chef-npm

--- a/providers/database.rb
+++ b/providers/database.rb
@@ -24,7 +24,7 @@ include InfluxDB::Helpers
 def initialize(new_resource, run_context)
   super
   @name    = new_resource.name
-  @client  = InfluxDB::Helpers.client('root', 'root', run_context)
+  @client  = InfluxDB::Helpers.client(new_resource.auth_username, new_resource.auth_password, run_context)
 end
 
 action :create do

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -23,7 +23,7 @@ include InfluxDB::Helpers
 
 def initialize(new_resource, run_context)
   super
-  @client      = InfluxDB::Helpers.client('root', 'root', run_context)
+  @client      = InfluxDB::Helpers.client(new_resource.auth_username, new_resource.auth_password, run_context)
   @username    = new_resource.username
   @password    = new_resource.password
   @databases   = new_resource.databases
@@ -51,7 +51,7 @@ action :update do
   end
   @databases.each do |db|
     @permissions.each do |permission|
-      @client.grant_user_privileges(@username, @db, permission)
+      @client.grant_user_privileges(@username, db, permission)
     end
   end
 end

--- a/resources/admin.rb
+++ b/resources/admin.rb
@@ -24,3 +24,6 @@ default_action(:create)
 
 attribute(:username, kind_of: String, name_attribute: true)
 attribute(:password, kind_of: String)
+
+attribute(:auth_username, kind_of: String, default: 'root')
+attribute(:auth_password, kind_of: String, default: 'root')

--- a/resources/database.rb
+++ b/resources/database.rb
@@ -23,3 +23,6 @@ actions(:create, :delete)
 default_action(:create)
 
 attribute(:name, kind_of: String, name_attribute: true)
+
+attribute(:auth_username, kind_of: String, default: 'root')
+attribute(:auth_password, kind_of: String, default: 'root')

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -26,3 +26,6 @@ attribute(:username, kind_of: String, name_attribute: true)
 attribute(:password, kind_of: String)
 attribute(:databases, kind_of: Array, required: false, default: [])
 attribute(:permissions, kind_of: Array, required: false, default: [])
+
+attribute(:auth_username, kind_of: String, default: 'root')
+attribute(:auth_password, kind_of: String, default: 'root')


### PR DESCRIPTION
Add auth_username and auth_password fields to the LWRPs to support auth-enabled Influx instances without root:root creds.  Resolves #42 