### PR TITLE
Do not retry indefinitely, fail after a reasonable timeout

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -29,7 +29,7 @@ module InfluxDB
     def self.client(user = 'root', pass = 'root', run_context)
       install_influxdb(run_context)
       require_influxdb
-      InfluxDB::Client.new(username: user, password: pass)
+      InfluxDB::Client.new(username: user, password: pass, retry: 10)
     end
 
     def self.render_config(hash, run_context, config_file)


### PR DESCRIPTION
Currently if InfluxDB is down the influx gem will retry indefinitely, blocking Chef until InfluxDB comes up.  This PR adds a timeout (currently fixed to 10 retries) so that the chef run will eventually fail if Influx is down.  This should bring behavior inline with what most users would expect.