### PR TITLE
Multiple fixes

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -29,7 +29,7 @@ module InfluxDB
     def self.client(user = 'root', pass = 'root', run_context)
       install_influxdb(run_context)
       require_influxdb
-      InfluxDB::Client.new(username: user, password: pass)
+      InfluxDB::Client.new(username: user, password: pass, retry: 10)
     end
 
     def self.render_config(hash, run_context, config_file)

--- a/metadata.rb
+++ b/metadata.rb
@@ -20,7 +20,7 @@ maintainer       'Simple Finance Technology Corp'
 maintainer_email 'ops@simple.com'
 license          'Apache 2.0'
 description      'InfluxDB, a timeseries database'
-version          '3.1.0'
+version          '3.1.1'
 
 # For CLI client
 # https://github.com/balbeko/chef-npm

--- a/metadata.rb
+++ b/metadata.rb
@@ -20,7 +20,7 @@ maintainer       'Simple Finance Technology Corp'
 maintainer_email 'ops@simple.com'
 license          'Apache 2.0'
 description      'InfluxDB, a timeseries database'
-version          '3.1.1'
+version          '3.1.2'
 
 # For CLI client
 # https://github.com/balbeko/chef-npm

--- a/metadata.rb
+++ b/metadata.rb
@@ -20,7 +20,7 @@ maintainer       'Simple Finance Technology Corp'
 maintainer_email 'ops@simple.com'
 license          'Apache 2.0'
 description      'InfluxDB, a timeseries database'
-version          '3.0.0'
+version          '3.1.0'
 
 # For CLI client
 # https://github.com/balbeko/chef-npm

--- a/providers/admin.rb
+++ b/providers/admin.rb
@@ -30,7 +30,7 @@ end
 
 action :create do
   unless @password
-    Chef::Log.fatal!('You must provide a password for the :create' \
+    fail('You must provide a password for the :create' \
                      ' action on this resource!')
   end
 
@@ -50,7 +50,7 @@ end
 
 action :update do
   unless @password
-    Chef::Log.fatal!('You must provide a password for the :update' \
+    fail('You must provide a password for the :update' \
                      ' action on this resource!')
   end
   @client.update_user_password(@username, @password)

--- a/providers/database.rb
+++ b/providers/database.rb
@@ -24,7 +24,7 @@ include InfluxDB::Helpers
 def initialize(new_resource, run_context)
   super
   @name    = new_resource.name
-  @client  = InfluxDB::Helpers.client('root', 'root', run_context)
+  @client  = InfluxDB::Helpers.client(new_resource.auth_username, new_resource.auth_password, run_context)
 end
 
 action :create do

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -23,7 +23,7 @@ include InfluxDB::Helpers
 
 def initialize(new_resource, run_context)
   super
-  @client      = InfluxDB::Helpers.client('root', 'root', run_context)
+  @client      = InfluxDB::Helpers.client(new_resource.auth_username, new_resource.auth_password, run_context)
   @username    = new_resource.username
   @password    = new_resource.password
   @databases   = new_resource.databases
@@ -51,7 +51,7 @@ action :update do
   end
   @databases.each do |db|
     @permissions.each do |permission|
-      @client.grant_user_privileges(@username, @db, permission)
+      @client.grant_user_privileges(@username, db, permission)
     end
   end
 end

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -32,7 +32,7 @@ end
 
 action :create do
   unless @password
-    Chef::Log.fatal!('You must provide a password for the :create' \
+    fail('You must provide a password for the :create' \
                      ' action on this resource')
   end
   @databases.each do |db|

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -40,7 +40,7 @@ action :create do
       @client.create_database_user(db, @username, @password)
     end
     @permissions.each do |permission|
-      @client.grant_user_privileges(db, @username, permission)
+      @client.grant_user_privileges(@username, db, permission)
     end
   end
 end

--- a/resources/admin.rb
+++ b/resources/admin.rb
@@ -24,3 +24,6 @@ default_action(:create)
 
 attribute(:username, kind_of: String, name_attribute: true)
 attribute(:password, kind_of: String)
+
+attribute(:auth_username, kind_of: String, default: 'root')
+attribute(:auth_password, kind_of: String, default: 'root')

--- a/resources/database.rb
+++ b/resources/database.rb
@@ -23,3 +23,6 @@ actions(:create, :delete)
 default_action(:create)
 
 attribute(:name, kind_of: String, name_attribute: true)
+
+attribute(:auth_username, kind_of: String, default: 'root')
+attribute(:auth_password, kind_of: String, default: 'root')

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -26,3 +26,6 @@ attribute(:username, kind_of: String, name_attribute: true)
 attribute(:password, kind_of: String)
 attribute(:databases, kind_of: Array, required: false, default: [])
 attribute(:permissions, kind_of: Array, required: false, default: [])
+
+attribute(:auth_username, kind_of: String, default: 'root')
+attribute(:auth_password, kind_of: String, default: 'root')


### PR DESCRIPTION
Merging multiple pulls into one as they would conflict individually.

- Add auth_username and auth_password fields to the LWRPs to support auth-enabled Influx instances without root:root creds. Resolves #42 (Formerly #76)
- Add a retry limit to the LWRP so that it will not block indefinitely if Influx is down (Formerly #77)
- Fix bad arguments to grant_user_privileges(), db and username arguments were reversed.