### PR TITLE
Add Retention policies LWRP

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,24 @@ influxdb_admin 'admin' do
   password 'changeme'
   action :create
 end
+
 ```
+
+### influxdb\_retention\_policy
+Configures a retention policy on a given database.
+The name attribute is not used, the database and policy name provide the unique names used by Influx.
+
+```ruby
+  influxdb_retention_policy "foodb default retention policy" do
+  policy_name 'default'
+  database    'foodb'
+  duration    '1w'
+  replication 1
+  action :create
+end
+
+```
+
 
 ## Client Libraries
 Right now, this cookbook only supports the Ruby and CLI client libraries so as

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -176,3 +176,10 @@ default[:influxdb][:config] = {
 
 # For some backwards-compatibility
 default[:influxdb][:zero_nine][:config] = node[:influxdb][:config]
+
+# Gem settings for the LWRPs
+# Load a custom gem containing:
+#  Fix show policies syntax: d929e386d4aa6203489eae47ad3e96b9b7c064cc - https://github.com/influxdb/influxdb-ruby/pull/109
+#  Add alter_retention_policy(): 14595de93f1433f342ef4d03a09597df48f11feb - https://github.com/influxdb/influxdb-ruby/pull/114
+# Built off https://github.com/CVTJNII/influxdb-ruby
+default[:influxdb][:gem][:http_source] = 'https://github.com/CVTJNII/gemshare/raw/master/influxdb-0.2.3.gem'

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -29,7 +29,7 @@ module InfluxDB
     def self.client(user = 'root', pass = 'root', run_context)
       install_influxdb(run_context)
       require_influxdb
-      InfluxDB::Client.new(username: user, password: pass)
+      InfluxDB::Client.new(username: user, password: pass, retry: 10)
     end
 
     def self.render_config(hash, run_context, config_file)

--- a/metadata.rb
+++ b/metadata.rb
@@ -20,7 +20,7 @@ maintainer       'Simple Finance Technology Corp'
 maintainer_email 'ops@simple.com'
 license          'Apache 2.0'
 description      'InfluxDB, a timeseries database'
-version          '3.1.2'
+version          '3.2.0'
 
 # For CLI client
 # https://github.com/balbeko/chef-npm

--- a/metadata.rb
+++ b/metadata.rb
@@ -20,7 +20,7 @@ maintainer       'Simple Finance Technology Corp'
 maintainer_email 'ops@simple.com'
 license          'Apache 2.0'
 description      'InfluxDB, a timeseries database'
-version          '3.1.0'
+version          '3.1.1'
 
 # For CLI client
 # https://github.com/balbeko/chef-npm

--- a/metadata.rb
+++ b/metadata.rb
@@ -20,7 +20,7 @@ maintainer       'Simple Finance Technology Corp'
 maintainer_email 'ops@simple.com'
 license          'Apache 2.0'
 description      'InfluxDB, a timeseries database'
-version          '3.1.1'
+version          '3.1.2'
 
 # For CLI client
 # https://github.com/balbeko/chef-npm

--- a/metadata.rb
+++ b/metadata.rb
@@ -20,7 +20,7 @@ maintainer       'Simple Finance Technology Corp'
 maintainer_email 'ops@simple.com'
 license          'Apache 2.0'
 description      'InfluxDB, a timeseries database'
-version          '3.0.0'
+version          '3.1.0'
 
 # For CLI client
 # https://github.com/balbeko/chef-npm

--- a/providers/admin.rb
+++ b/providers/admin.rb
@@ -30,7 +30,7 @@ end
 
 action :create do
   unless @password
-    Chef::Log.fatal!('You must provide a password for the :create' \
+    fail('You must provide a password for the :create' \
                      ' action on this resource!')
   end
 
@@ -50,7 +50,7 @@ end
 
 action :update do
   unless @password
-    Chef::Log.fatal!('You must provide a password for the :update' \
+    fail('You must provide a password for the :update' \
                      ' action on this resource!')
   end
   @client.update_user_password(@username, @password)

--- a/providers/database.rb
+++ b/providers/database.rb
@@ -24,7 +24,7 @@ include InfluxDB::Helpers
 def initialize(new_resource, run_context)
   super
   @name    = new_resource.name
-  @client  = InfluxDB::Helpers.client('root', 'root', run_context)
+  @client  = InfluxDB::Helpers.client(new_resource.auth_username, new_resource.auth_password, run_context)
 end
 
 action :create do

--- a/providers/retention_policy.rb
+++ b/providers/retention_policy.rb
@@ -1,0 +1,62 @@
+# providers/database.rb
+#
+# Author: Simple Finance <ops@simple.com>
+# License: Apache License, Version 2.0
+#
+# Copyright 2013 Simple Finance Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Creates or deletes an InfluxDB database
+
+include InfluxDB::Helpers
+
+def initialize(new_resource, run_context)
+  super
+  @name    = new_resource.name
+  @client  = InfluxDB::Helpers.client(new_resource.auth_username, new_resource.auth_password, run_context)
+
+  @policy_name = new_resource.policy_name
+  @database    = new_resource.database
+  @duration    = new_resource.duration
+  @replication = new_resource.replication
+  @default     = new_resource.default
+end
+
+action :create do
+  current_policy = _get_current_policy
+  if current_policy
+    if current_policy['duration'] != @duration || current_policy['replicaN'] != replication || current_policy['default'] != @default
+      @client.alter_retention_policy(@policy_name, @database, @duration, @replication, @default)
+    end
+  else
+      @client.create_retention_policy(@policy_name, @database, @duration, @replication, @default)
+  end                                                   
+end
+
+action :delete do
+  current_policy = _get_current_policy
+  if current_policy
+    @client.delete_retention_policy(@policy_name, @database)
+  end
+end
+
+def _get_current_policy
+  current_policy_arr = @client.list_retention_policies(@database).select { |p| p['name'] == @policy_name } 
+  if current_policy_arr.length > 0
+    fail("Unexpected number of matches for retention policy #{@policy_name} on database #{@database}: #{current_policy_arr}") if current_policy_arr.length > 1
+    return current_policy_arr[0]
+  else
+    return nil
+  end
+end

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -23,7 +23,7 @@ include InfluxDB::Helpers
 
 def initialize(new_resource, run_context)
   super
-  @client      = InfluxDB::Helpers.client('root', 'root', run_context)
+  @client      = InfluxDB::Helpers.client(new_resource.auth_username, new_resource.auth_password, run_context)
   @username    = new_resource.username
   @password    = new_resource.password
   @databases   = new_resource.databases
@@ -51,7 +51,7 @@ action :update do
   end
   @databases.each do |db|
     @permissions.each do |permission|
-      @client.grant_user_privileges(@username, @db, permission)
+      @client.grant_user_privileges(@username, db, permission)
     end
   end
 end

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -32,7 +32,7 @@ end
 
 action :create do
   unless @password
-    Chef::Log.fatal!('You must provide a password for the :create' \
+    fail('You must provide a password for the :create' \
                      ' action on this resource')
   end
   @databases.each do |db|

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -40,7 +40,7 @@ action :create do
       @client.create_database_user(db, @username, @password)
     end
     @permissions.each do |permission|
-      @client.grant_user_privileges(db, @username, permission)
+      @client.grant_user_privileges(@username, db, permission)
     end
   end
 end

--- a/resources/admin.rb
+++ b/resources/admin.rb
@@ -24,3 +24,6 @@ default_action(:create)
 
 attribute(:username, kind_of: String, name_attribute: true)
 attribute(:password, kind_of: String)
+
+attribute(:auth_username, kind_of: String, default: 'root')
+attribute(:auth_password, kind_of: String, default: 'root')

--- a/resources/database.rb
+++ b/resources/database.rb
@@ -23,3 +23,6 @@ actions(:create, :delete)
 default_action(:create)
 
 attribute(:name, kind_of: String, name_attribute: true)
+
+attribute(:auth_username, kind_of: String, default: 'root')
+attribute(:auth_password, kind_of: String, default: 'root')

--- a/resources/retention_policy.rb
+++ b/resources/retention_policy.rb
@@ -1,0 +1,32 @@
+# resources/database.rb
+#
+# License: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# LWRP for InfluxDB database
+
+actions(:create, :delete)
+default_action(:create)
+
+attribute(:name, kind_of: String, name_attribute: true)
+
+attribute(:policy_name, kind_of: String)
+attribute(:database,    kind_of: String)
+attribute(:duration,    kind_of: String, default: 'INF')
+attribute(:replication, kind_of: Fixnum, default: 1)
+attribute(:default,     kind_of: [TrueClass, FalseClass], default: false)
+
+attribute(:auth_username, kind_of: String, default: 'root')
+attribute(:auth_password, kind_of: String, default: 'root')
+

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -26,3 +26,6 @@ attribute(:username, kind_of: String, name_attribute: true)
 attribute(:password, kind_of: String)
 attribute(:databases, kind_of: Array, required: false, default: [])
 attribute(:permissions, kind_of: Array, required: false, default: [])
+
+attribute(:auth_username, kind_of: String, default: 'root')
+attribute(:auth_password, kind_of: String, default: 'root')


### PR DESCRIPTION
This pull adds a LWRP to control InfluxDB retention policies.  It contains the pulls from Issue #78 but I have separated it to avoid further muddying that already large PR.

There are two major commits to this PR (on top of #78):
- 2d757f244f59b260a8976f89021cc361439848b0 Adds the LWRP
- a8a022dd26d363c8f69f0e4bdbfb207261bd6e19 Adds support to pull in a custom Influx gem over HTTP.

a8a022dd26d363c8f69f0e4bdbfb207261bd6e19 is required as this pull relies on functionality in the upstream Gem proposed in https://github.com/influxdb/influxdb-ruby/pull/109 and https://github.com/influxdb/influxdb-ruby/pull/114.  Once those pulls are merged and released in the Gem a8a022dd26d363c8f69f0e4bdbfb207261bd6e19 can be reverted.