### PR TITLE
Compat resources

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,21 +6,33 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: ubuntu-14.04
+<% %w(12.5 12.4 12.3 12.2 12.1).each do |chef_version| %>
+  - name: ubuntu-14.04-chef<%= chef_version %>
     driver:
       box: bento/ubuntu-14.04
-  - name: ubuntu-15.04
+    provisioner:
+      require_chef_omnibus: <%= chef_version %>
+  - name: ubuntu-15.04-chef<%= chef_version %>
     driver:
       box: bento/ubuntu-15.04
-  - name: debian-8.2
+    provisioner:
+      require_chef_omnibus: <%= chef_version %>
+  - name: debian-8.2-chef<%= chef_version %>
     driver:
       box: bento/debian-8.2
-  - name: centos-6.7
+    provisioner:
+      require_chef_omnibus: <%= chef_version %>
+  - name: centos-6.7-chef<%= chef_version %>
     driver:
       box: bento/centos-6.7
-  - name: centos-7.1
+    provisioner:
+      require_chef_omnibus: <%= chef_version %>
+  - name: centos-7.1-chef<%= chef_version %>
     driver:
       box: bento/centos-7.1
+    provisioner:
+      require_chef_omnibus: <%= chef_version %>
+<% end %>
 
 suites:
   - name: default

--- a/metadata.rb
+++ b/metadata.rb
@@ -33,3 +33,6 @@ depends 'chef_handler'
 # For apt and yum repositories
 depends 'apt', '~> 2.8'
 depends 'yum', '~> 3.8'
+
+# For compatibility with 12.X versions of Chef
+depends 'compat_resource'


### PR DESCRIPTION
This adds support back for older versions of Chef. The [`compat_resource`](https://supermarket.chef.io/cookbooks/compat_resource) cookbook backports the new resource format to Chef 12.1 - 12.4. This also adds runs tests on different versions of Chef.

I've ran tests on Chef 12.1 on Ubuntu 14.04 to verify the backwards compatibility.

This should resolve #83 assuming Chef >= 12.1 is acceptable.