### PR TITLE
Fix yum repository url for RHEL 7

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -121,3 +121,15 @@ default['influxdb']['config'] = {
 #  Add alter_retention_policy(): 14595de93f1433f342ef4d03a09597df48f11feb - https://github.com/influxdb/influxdb-ruby/pull/114
 # Built off https://github.com/CVTJNII/influxdb-ruby
 default['influxdb']['gem']['http_source'] = 'https://github.com/CVTJNII/gemshare/raw/master/influxdb-0.2.3.gem'
+
+case node['platform_family']
+when 'rhel', 'fedora'
+  case node['platform']
+  when 'centos'
+    default['influxdb']['upstream_repository'] = "https://repos.influxdata.com/centos/#{node['platform_version'].to_i}/$basearch/stable"
+  else
+    default['influxdb']['upstream_repository'] = "https://repos.influxdata.com/rhel/#{node['platform_version'].to_i}/$basearch/stable"
+  end
+else
+  default['influxdb']['upstream_repository'] = "https://repos.influxdata.com/#{node['platform']}"
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -42,14 +42,14 @@ end
 if platform_family? 'rhel'
   yum_repository 'influxdb' do
     description 'InfluxDB Repository - RHEL \$releasever'
-    baseurl 'https://repos.influxdata.com/centos/\$releasever/\$basearch/stable'
+    baseurl node['influxdb']['upstream_repository']
     gpgkey 'https://repos.influxdata.com/influxdb.key'
   end
 else
   package 'apt-transport-https'
 
   apt_repository 'influxdb' do
-    uri "https://repos.influxdata.com/#{node['platform']}"
+    uri node['influxdb']['upstream_repository']
     distribution node['lsb']['codename']
     components ['stable']
     arch 'amd64'


### PR DESCRIPTION
The official influxdb repositories provide separate directories for RHEL and centos which was not accounted for.

Some RHEL distributions have a $releasever yum variable set as 6Server or 7Server for example which is not supported by the influxdb repositories. Such distributions fail to install influxdb due to a 404 error.